### PR TITLE
[UI/#8] 공통 컴포넌트 구현

### DIFF
--- a/app/src/main/java/org/sopt/melon/core/designsystem/component/DummyComponent.kt
+++ b/app/src/main/java/org/sopt/melon/core/designsystem/component/DummyComponent.kt
@@ -1,1 +1,0 @@
-package org.sopt.melon.core.designsystem.component

--- a/app/src/main/java/org/sopt/melon/core/designsystem/component/MelonActionSnackbar.kt
+++ b/app/src/main/java/org/sopt/melon/core/designsystem/component/MelonActionSnackbar.kt
@@ -26,11 +26,12 @@ fun MelonActionSnackbar(
     modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(size = 4.dp))
-            .background(color = MELONTheme.colors.neonPink)
-            .padding(vertical = 14.dp, horizontal = 16.dp),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(size = 4.dp))
+                .background(color = MELONTheme.colors.neonPink)
+                .padding(vertical = 14.dp, horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
@@ -44,8 +45,9 @@ fun MelonActionSnackbar(
             text = actionLabel,
             style = MELONTheme.typography.body.r_14,
             color = MELONTheme.colors.white,
-            modifier = Modifier
-                .noRippleClickable(onClick = action),
+            modifier =
+                Modifier
+                    .noRippleClickable(onClick = action),
         )
     }
 }

--- a/app/src/main/java/org/sopt/melon/core/designsystem/component/MelonActionSnackbar.kt
+++ b/app/src/main/java/org/sopt/melon/core/designsystem/component/MelonActionSnackbar.kt
@@ -1,0 +1,70 @@
+package org.sopt.melon.core.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.sopt.melon.core.common.util.noRippleClickable
+import org.sopt.melon.core.designsystem.theme.MELONTheme
+
+@Composable
+fun MelonActionSnackbar(
+    message: String,
+    actionLabel: String,
+    action: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(size = 4.dp))
+            .background(color = MELONTheme.colors.neonPink)
+            .padding(vertical = 14.dp, horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = message,
+            style = MELONTheme.typography.body.m_14,
+            color = MELONTheme.colors.white,
+        )
+
+        Text(
+            text = actionLabel,
+            style = MELONTheme.typography.body.r_14,
+            color = MELONTheme.colors.white,
+            modifier = Modifier
+                .noRippleClickable(onClick = action),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MelonActionSnackbarPreview() {
+    MELONTheme {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Bottom,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            MelonActionSnackbar(
+                message = "믹스업에 추가되었어요",
+                actionLabel = "이동",
+                action = {},
+                modifier = Modifier.padding(16.dp),
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/sopt/melon/presentation/home/component/HomePopularGrid.kt
+++ b/app/src/main/java/org/sopt/melon/presentation/home/component/HomePopularGrid.kt
@@ -43,8 +43,9 @@ fun HomePopularGrid(
 ) {
     LazyHorizontalGrid(
         rows = GridCells.Fixed(cellCount),
-        modifier = modifier
-            .height(203.dp),
+        modifier =
+            modifier
+                .height(203.dp),
         state = gridState,
         contentPadding = PaddingValues(horizontal = 20.dp),
         horizontalArrangement = Arrangement.spacedBy(24.dp),
@@ -78,18 +79,19 @@ private fun PopularSongItem(
             contentScale = ContentScale.Crop,
             contentDescription = null,
             error = painterResource(img_home2_56),
-            modifier = Modifier
-                .size(size = 56.dp)
-                .clip(RoundedCornerShape(6.dp)),
+            modifier =
+                Modifier
+                    .size(size = 56.dp)
+                    .clip(RoundedCornerShape(6.dp)),
         )
 
         Column(
-            modifier = Modifier
-                .padding(
-                    start = 12.dp,
-                    end = 24.dp,
-                )
-                .width(138.dp),
+            modifier =
+                Modifier
+                    .padding(
+                        start = 12.dp,
+                        end = 24.dp,
+                    ).width(138.dp),
         ) {
             Text(
                 text = subtitle,
@@ -113,8 +115,9 @@ private fun PopularSongItem(
         Image(
             painter = painterResource(id = img_mixup_36),
             contentDescription = null,
-            modifier = Modifier
-                .size(36.dp),
+            modifier =
+                Modifier
+                    .size(36.dp),
         )
     }
 }
@@ -123,48 +126,50 @@ private fun PopularSongItem(
 @Composable
 private fun HomePopularGridPreview() {
     MELONTheme {
-        val list = persistentListOf(
-            PopularSongData(
-                imgUrl = "",
-                subtitle = "멜론DJ's Pick",
-                title = "1XOXZ",
-                artistName = "IVE (아이브)",
-            ),
-            PopularSongData(
-                imgUrl = "",
-                subtitle = "멜론DJ's Pick",
-                title = "2XOXZ",
-                artistName = "IVE (아이브)",
-            ),
-            PopularSongData(
-                imgUrl = "",
-                subtitle = "멜론DJ's Pick",
-                title = "3XOXZ",
-                artistName = "Hearts2Hearts(하츠투하츠)",
-            ),
-            PopularSongData(
-                imgUrl = "",
-                subtitle = "멜론DJ's Pick",
-                title = "4XOXZ",
-                artistName = "IVE (아이브)",
-            ),
-            PopularSongData(
-                imgUrl = "",
-                subtitle = "멜론DJ's Pick",
-                title = "5XOXZ",
-                artistName = "IVE (아이브)",
-            ),
-            PopularSongData(
-                imgUrl = "",
-                subtitle = "멜론DJ's Pick",
-                title = "6XOXZ",
-                artistName = "IVE (아이브)",
-            ),
-        )
+        val list =
+            persistentListOf(
+                PopularSongData(
+                    imgUrl = "",
+                    subtitle = "멜론DJ's Pick",
+                    title = "1XOXZ",
+                    artistName = "IVE (아이브)",
+                ),
+                PopularSongData(
+                    imgUrl = "",
+                    subtitle = "멜론DJ's Pick",
+                    title = "2XOXZ",
+                    artistName = "IVE (아이브)",
+                ),
+                PopularSongData(
+                    imgUrl = "",
+                    subtitle = "멜론DJ's Pick",
+                    title = "3XOXZ",
+                    artistName = "Hearts2Hearts(하츠투하츠)",
+                ),
+                PopularSongData(
+                    imgUrl = "",
+                    subtitle = "멜론DJ's Pick",
+                    title = "4XOXZ",
+                    artistName = "IVE (아이브)",
+                ),
+                PopularSongData(
+                    imgUrl = "",
+                    subtitle = "멜론DJ's Pick",
+                    title = "5XOXZ",
+                    artistName = "IVE (아이브)",
+                ),
+                PopularSongData(
+                    imgUrl = "",
+                    subtitle = "멜론DJ's Pick",
+                    title = "6XOXZ",
+                    artistName = "IVE (아이브)",
+                ),
+            )
         Column(
-            modifier = Modifier
-                .background(color = MELONTheme.colors.background)
-                .fillMaxSize(),
+            modifier =
+                Modifier
+                    .background(color = MELONTheme.colors.background)
+                    .fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {

--- a/app/src/main/java/org/sopt/melon/presentation/home/component/HomePopularGrid.kt
+++ b/app/src/main/java/org/sopt/melon/presentation/home/component/HomePopularGrid.kt
@@ -95,8 +95,7 @@ private fun PopularSongItem(
                     .padding(
                         start = 12.dp,
                         end = 24.dp,
-                    )
-                    .width(138.dp),
+                    ).width(138.dp),
         ) {
             Text(
                 text = subtitle,

--- a/app/src/main/java/org/sopt/melon/presentation/home/component/HomePopularGrid.kt
+++ b/app/src/main/java/org/sopt/melon/presentation/home/component/HomePopularGrid.kt
@@ -1,0 +1,177 @@
+package org.sopt.melon.presentation.home.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.grid.LazyHorizontalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import org.sopt.melon.R.drawable.img_home2_56
+import org.sopt.melon.R.drawable.img_mixup_36
+import org.sopt.melon.core.designsystem.theme.MELONTheme
+import org.sopt.melon.presentation.home.model.PopularSongData
+
+@Composable
+fun HomePopularGrid(
+    popularSongList: ImmutableList<PopularSongData>,
+    gridState: LazyGridState,
+    modifier: Modifier = Modifier,
+    cellCount: Int = 3,
+) {
+    LazyHorizontalGrid(
+        rows = GridCells.Fixed(cellCount),
+        modifier = modifier
+            .height(203.dp),
+        state = gridState,
+        contentPadding = PaddingValues(horizontal = 20.dp),
+        horizontalArrangement = Arrangement.spacedBy(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        items(popularSongList) { song ->
+            PopularSongItem(
+                imgUrl = song.imgUrl,
+                subtitle = song.subtitle,
+                title = song.title,
+                artistName = song.artistName,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PopularSongItem(
+    imgUrl: String,
+    subtitle: String,
+    title: String,
+    artistName: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AsyncImage(
+            model = imgUrl,
+            contentScale = ContentScale.Crop,
+            contentDescription = null,
+            error = painterResource(img_home2_56),
+            modifier = Modifier
+                .size(size = 56.dp)
+                .clip(RoundedCornerShape(6.dp)),
+        )
+
+        Column(
+            modifier = Modifier
+                .padding(
+                    start = 12.dp,
+                    end = 24.dp,
+                )
+                .width(138.dp),
+        ) {
+            Text(
+                text = subtitle,
+                style = MELONTheme.typography.caption.r_12,
+                color = MELONTheme.colors.gray200,
+            )
+
+            Text(
+                text = title,
+                style = MELONTheme.typography.body.r_14,
+                color = MELONTheme.colors.white,
+            )
+
+            Text(
+                text = artistName,
+                style = MELONTheme.typography.caption.r_12,
+                color = MELONTheme.colors.gray200,
+            )
+        }
+
+        Image(
+            painter = painterResource(id = img_mixup_36),
+            contentDescription = null,
+            modifier = Modifier
+                .size(36.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HomePopularGridPreview() {
+    MELONTheme {
+        val list = persistentListOf(
+            PopularSongData(
+                imgUrl = "",
+                subtitle = "멜론DJ's Pick",
+                title = "1XOXZ",
+                artistName = "IVE (아이브)",
+            ),
+            PopularSongData(
+                imgUrl = "",
+                subtitle = "멜론DJ's Pick",
+                title = "2XOXZ",
+                artistName = "IVE (아이브)",
+            ),
+            PopularSongData(
+                imgUrl = "",
+                subtitle = "멜론DJ's Pick",
+                title = "3XOXZ",
+                artistName = "Hearts2Hearts(하츠투하츠)",
+            ),
+            PopularSongData(
+                imgUrl = "",
+                subtitle = "멜론DJ's Pick",
+                title = "4XOXZ",
+                artistName = "IVE (아이브)",
+            ),
+            PopularSongData(
+                imgUrl = "",
+                subtitle = "멜론DJ's Pick",
+                title = "5XOXZ",
+                artistName = "IVE (아이브)",
+            ),
+            PopularSongData(
+                imgUrl = "",
+                subtitle = "멜론DJ's Pick",
+                title = "6XOXZ",
+                artistName = "IVE (아이브)",
+            ),
+        )
+        Column(
+            modifier = Modifier
+                .background(color = MELONTheme.colors.background)
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            HomePopularGrid(
+                popularSongList = list,
+                gridState = rememberLazyGridState(),
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/sopt/melon/presentation/home/component/HomePopularGrid.kt
+++ b/app/src/main/java/org/sopt/melon/presentation/home/component/HomePopularGrid.kt
@@ -31,6 +31,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import org.sopt.melon.R.drawable.img_home2_56
 import org.sopt.melon.R.drawable.img_mixup_36
+import org.sopt.melon.core.common.util.noRippleClickable
 import org.sopt.melon.core.designsystem.theme.MELONTheme
 import org.sopt.melon.presentation.home.model.PopularSongData
 
@@ -38,6 +39,7 @@ import org.sopt.melon.presentation.home.model.PopularSongData
 fun HomePopularGrid(
     popularSongList: ImmutableList<PopularSongData>,
     gridState: LazyGridState,
+    onMixUpClick: () -> Unit,
     modifier: Modifier = Modifier,
     cellCount: Int = 3,
 ) {
@@ -57,6 +59,7 @@ fun HomePopularGrid(
                 subtitle = song.subtitle,
                 title = song.title,
                 artistName = song.artistName,
+                onMixUpClick = onMixUpClick,
             )
         }
     }
@@ -68,6 +71,7 @@ private fun PopularSongItem(
     subtitle: String,
     title: String,
     artistName: String,
+    onMixUpClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -91,7 +95,8 @@ private fun PopularSongItem(
                     .padding(
                         start = 12.dp,
                         end = 24.dp,
-                    ).width(138.dp),
+                    )
+                    .width(138.dp),
         ) {
             Text(
                 text = subtitle,
@@ -117,7 +122,8 @@ private fun PopularSongItem(
             contentDescription = null,
             modifier =
                 Modifier
-                    .size(36.dp),
+                    .size(36.dp)
+                    .noRippleClickable(onClick = onMixUpClick),
         )
     }
 }
@@ -176,6 +182,7 @@ private fun HomePopularGridPreview() {
             HomePopularGrid(
                 popularSongList = list,
                 gridState = rememberLazyGridState(),
+                onMixUpClick = {},
             )
         }
     }

--- a/app/src/main/java/org/sopt/melon/presentation/home/model/PopularSongData.kt
+++ b/app/src/main/java/org/sopt/melon/presentation/home/model/PopularSongData.kt
@@ -1,0 +1,8 @@
+package org.sopt.melon.presentation.home.model
+
+data class PopularSongData(
+    val imgUrl: String,
+    val subtitle: String,
+    val title: String,
+    val artistName: String,
+)

--- a/app/src/main/java/org/sopt/melon/presentation/main/MainActivity.kt
+++ b/app/src/main/java/org/sopt/melon/presentation/main/MainActivity.kt
@@ -15,6 +15,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge(
             statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
+            navigationBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
         )
 
         setContent {

--- a/app/src/main/java/org/sopt/melon/presentation/mixup/MixUpScreen.kt
+++ b/app/src/main/java/org/sopt/melon/presentation/mixup/MixUpScreen.kt
@@ -21,15 +21,16 @@ private fun MixUpScreen(
 ) {
     val colors = MELONTheme.colors
     Column(
-        modifier = modifier
-            .fillMaxSize()
-            .drawWithCache {
-                onDrawBehind {
-                    drawRect(
-                        brush = colors.gradient3,
-                    )
-                }
-            },
+        modifier =
+            modifier
+                .fillMaxSize()
+                .drawWithCache {
+                    onDrawBehind {
+                        drawRect(
+                            brush = colors.gradient3,
+                        )
+                    }
+                },
     ) {
     }
 }

--- a/app/src/main/java/org/sopt/melon/presentation/mixup/MixUpScreen.kt
+++ b/app/src/main/java/org/sopt/melon/presentation/mixup/MixUpScreen.kt
@@ -1,10 +1,12 @@
 package org.sopt.melon.presentation.mixup
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.tooling.preview.Preview
+import org.sopt.melon.core.designsystem.theme.MELONTheme
 
 @Composable
 fun MixUpRoute(
@@ -17,9 +19,25 @@ fun MixUpRoute(
 private fun MixUpScreen(
     modifier: Modifier = Modifier,
 ) {
+    val colors = MELONTheme.colors
     Column(
-        modifier = modifier,
+        modifier = modifier
+            .fillMaxSize()
+            .drawWithCache {
+                onDrawBehind {
+                    drawRect(
+                        brush = colors.gradient3,
+                    )
+                }
+            },
     ) {
-        Text("MIXUP", color = Color.White)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MixUpPreview() {
+    MELONTheme {
+        MixUpScreen()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,7 @@
     <string name="drawer">음악서랍</string>
     <!--ShortCut  -->
     <string name="shortcut">바로가기</string>
+    <!--Snackbar  -->
+    <string name="snackbar_mixup_add_message">믹스업에 추가되었어요</string>
+    <string name="snackbar_move_action_label">이동</string>
 </resources>


### PR DESCRIPTION
## Related issue 🛠
- closed #8

## Work Description ✏️
- 스낵바
- 믹스업 리스트
- 믹스업 화면 그라디언트

## Screenshot 📸
| snackbar | gradient | popular grid |
|:---------:|:------------:|:---------:|
| <img src="https://github.com/user-attachments/assets/77fede4e-4d56-442c-8039-0983971dee4f" width="360"/> | <img src="https://github.com/user-attachments/assets/2666e76c-32b1-4727-9e41-f1993dbaf749" width="360"/> | <video src="https://github.com/user-attachments/assets/d48fdafb-8165-4451-b693-a4814806f566" width="360"/> |

## Uncompleted Tasks 😅
- [x] snackbar 호출 로직 처리 

## To Reviewers 📢
- grid 구현할때 높이를 지정하지 않으면 전체 영역을 가지게 되어서 이부분 높이를 지정했습니다. 
- 그라디언트는 기본적으로 start, end 설정 값이 좌상단에서 우하단으로 가기 때문에 기본 값으로 사용했습니다.
- 이미지 사용할때 AsyncImage 사용하시고 preview 에서도 확인하기 위해서 error 파라미터에 블루발렌타인 이미지 넣어주세요 ~!!