### PR TITLE
[FEAT/#14] Snackbar 로직 구현

### DIFF
--- a/app/src/main/java/org/sopt/melon/core/designsystem/component/snackbar/MelonActionSnackbar.kt
+++ b/app/src/main/java/org/sopt/melon/core/designsystem/component/snackbar/MelonActionSnackbar.kt
@@ -1,4 +1,4 @@
-package org.sopt.melon.core.designsystem.component
+package org.sopt.melon.core.designsystem.component.snackbar
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement

--- a/app/src/main/java/org/sopt/melon/core/designsystem/component/snackbar/MelonSnackbarController.kt
+++ b/app/src/main/java/org/sopt/melon/core/designsystem/component/snackbar/MelonSnackbarController.kt
@@ -24,30 +24,33 @@ class MelonSnackbarController(
 
     private var actionJob: Job? = null
     private var timerJob: Job? = null
+
     fun show(request: MelonSnackbarRequest) {
         currentRequest = request
 
         coroutineScope.launch {
             clearCurrentSnackbar()
 
-            val job = launch {
-                snackbarHostState.showSnackbar(
-                    message = request.message,
-                    actionLabel = request.actionLabel,
-                    withDismissAction = true,
-                )
-            }
+            val job =
+                launch {
+                    snackbarHostState.showSnackbar(
+                        message = request.message,
+                        actionLabel = request.actionLabel,
+                        withDismissAction = true,
+                    )
+                }
             actionJob = job
 
-            timerJob = launch {
-                delay(SNACKBAR_AUTO_DISMISS_MS)
-                if (actionJob == job) {
-                    job.cancel()
-                    currentRequest = null
-                    actionJob = null
-                    timerJob = null
+            timerJob =
+                launch {
+                    delay(SNACKBAR_AUTO_DISMISS_MS)
+                    if (actionJob == job) {
+                        job.cancel()
+                        currentRequest = null
+                        actionJob = null
+                        timerJob = null
+                    }
                 }
-            }
         }
     }
 
@@ -70,6 +73,7 @@ class MelonSnackbarController(
 @Composable
 fun rememberMelonSnackbarController(
     scope: CoroutineScope = rememberCoroutineScope(),
-): MelonSnackbarController = remember {
-    MelonSnackbarController(scope)
-}
+): MelonSnackbarController =
+    remember {
+        MelonSnackbarController(scope)
+    }

--- a/app/src/main/java/org/sopt/melon/core/designsystem/component/snackbar/MelonSnackbarController.kt
+++ b/app/src/main/java/org/sopt/melon/core/designsystem/component/snackbar/MelonSnackbarController.kt
@@ -1,0 +1,66 @@
+package org.sopt.melon.core.designsystem.component.snackbar
+
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+private const val SNACKBAR_AUTO_DISMISS_MS = 3000L
+
+class MelonSnackbarController(
+    private val coroutineScope: CoroutineScope,
+) {
+    val snackbarHostState = SnackbarHostState()
+
+    var currentRequest by mutableStateOf<MelonSnackbarRequest?>(null)
+        private set
+
+    fun show(request: MelonSnackbarRequest) {
+        currentRequest = request
+
+        coroutineScope.launch {
+            snackbarHostState.currentSnackbarData?.dismiss()
+
+            val job = launch {
+                snackbarHostState.showSnackbar(
+                    message = request.message,
+                    actionLabel = request.actionLabel,
+                    withDismissAction = true,
+                )
+            }
+
+            job.invokeOnCompletion {
+                if (currentRequest === request) {
+                    currentRequest = null
+                }
+            }
+
+            launch {
+                delay(SNACKBAR_AUTO_DISMISS_MS)
+                job.cancel()
+            }
+        }
+    }
+
+    fun performAction() {
+        currentRequest?.onClick?.invoke()
+        currentRequest = null
+
+        coroutineScope.launch {
+            snackbarHostState.currentSnackbarData?.dismiss()
+        }
+    }
+}
+
+@Composable
+fun rememberMelonSnackbarController(
+    scope: CoroutineScope = rememberCoroutineScope(),
+): MelonSnackbarController = remember {
+    MelonSnackbarController(scope)
+}

--- a/app/src/main/java/org/sopt/melon/core/designsystem/component/snackbar/MelonSnackbarController.kt
+++ b/app/src/main/java/org/sopt/melon/core/designsystem/component/snackbar/MelonSnackbarController.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -21,11 +22,13 @@ class MelonSnackbarController(
     var currentRequest by mutableStateOf<MelonSnackbarRequest?>(null)
         private set
 
+    private var actionJob: Job? = null
+    private var timerJob: Job? = null
     fun show(request: MelonSnackbarRequest) {
         currentRequest = request
 
         coroutineScope.launch {
-            snackbarHostState.currentSnackbarData?.dismiss()
+            clearCurrentSnackbar()
 
             val job = launch {
                 snackbarHostState.showSnackbar(
@@ -34,18 +37,24 @@ class MelonSnackbarController(
                     withDismissAction = true,
                 )
             }
+            actionJob = job
 
-            job.invokeOnCompletion {
-                if (currentRequest === request) {
+            timerJob = launch {
+                delay(SNACKBAR_AUTO_DISMISS_MS)
+                if (actionJob == job) {
+                    job.cancel()
                     currentRequest = null
+                    actionJob = null
+                    timerJob = null
                 }
             }
-
-            launch {
-                delay(SNACKBAR_AUTO_DISMISS_MS)
-                job.cancel()
-            }
         }
+    }
+
+    private fun clearCurrentSnackbar() {
+        actionJob?.cancel()
+        timerJob?.cancel()
+        snackbarHostState.currentSnackbarData?.dismiss()
     }
 
     fun performAction() {

--- a/app/src/main/java/org/sopt/melon/core/designsystem/component/snackbar/MelonSnackbarController.kt
+++ b/app/src/main/java/org/sopt/melon/core/designsystem/component/snackbar/MelonSnackbarController.kt
@@ -19,13 +19,13 @@ class MelonSnackbarController(
 ) {
     val snackbarHostState = SnackbarHostState()
 
-    var currentRequest by mutableStateOf<MelonSnackbarRequest?>(null)
+    var currentRequest by mutableStateOf<MelonSnackbarActionRequest?>(null)
         private set
 
     private var actionJob: Job? = null
     private var timerJob: Job? = null
 
-    fun show(request: MelonSnackbarRequest) {
+    fun show(request: MelonSnackbarActionRequest) {
         currentRequest = request
 
         coroutineScope.launch {

--- a/app/src/main/java/org/sopt/melon/core/designsystem/component/snackbar/MelonSnackbarModel.kt
+++ b/app/src/main/java/org/sopt/melon/core/designsystem/component/snackbar/MelonSnackbarModel.kt
@@ -1,0 +1,15 @@
+package org.sopt.melon.core.designsystem.component.snackbar
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+
+@Immutable
+data class MelonSnackbarRequest(
+    val message: String,
+    val actionLabel: String,
+    val onClick: () -> Unit,
+)
+
+val LocalMelonSnackbarTrigger = staticCompositionLocalOf<(MelonSnackbarRequest) -> Unit> {
+    error("No MelonSnackbarTrigger provided")
+}

--- a/app/src/main/java/org/sopt/melon/core/designsystem/component/snackbar/MelonSnackbarModel.kt
+++ b/app/src/main/java/org/sopt/melon/core/designsystem/component/snackbar/MelonSnackbarModel.kt
@@ -4,13 +4,13 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.staticCompositionLocalOf
 
 @Immutable
-data class MelonSnackbarRequest(
+data class MelonSnackbarActionRequest(
     val message: String,
     val actionLabel: String,
     val onClick: () -> Unit,
 )
 
 val LocalMelonSnackbarTrigger =
-    staticCompositionLocalOf<(MelonSnackbarRequest) -> Unit> {
+    staticCompositionLocalOf<(MelonSnackbarActionRequest) -> Unit> {
         error("No MelonSnackbarTrigger provided")
     }

--- a/app/src/main/java/org/sopt/melon/core/designsystem/component/snackbar/MelonSnackbarModel.kt
+++ b/app/src/main/java/org/sopt/melon/core/designsystem/component/snackbar/MelonSnackbarModel.kt
@@ -10,6 +10,7 @@ data class MelonSnackbarRequest(
     val onClick: () -> Unit,
 )
 
-val LocalMelonSnackbarTrigger = staticCompositionLocalOf<(MelonSnackbarRequest) -> Unit> {
-    error("No MelonSnackbarTrigger provided")
-}
+val LocalMelonSnackbarTrigger =
+    staticCompositionLocalOf<(MelonSnackbarRequest) -> Unit> {
+        error("No MelonSnackbarTrigger provided")
+    }

--- a/app/src/main/java/org/sopt/melon/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/org/sopt/melon/presentation/home/HomeScreen.kt
@@ -15,7 +15,7 @@ import org.sopt.melon.R.string.snackbar_mixup_add_message
 import org.sopt.melon.R.string.snackbar_move_action_label
 import org.sopt.melon.core.common.util.noRippleClickable
 import org.sopt.melon.core.designsystem.component.snackbar.LocalMelonSnackbarTrigger
-import org.sopt.melon.core.designsystem.component.snackbar.MelonSnackbarRequest
+import org.sopt.melon.core.designsystem.component.snackbar.MelonSnackbarActionRequest
 
 @Composable
 fun HomeRoute(
@@ -24,7 +24,7 @@ fun HomeRoute(
 ) {
     val snackbarTrigger = LocalMelonSnackbarTrigger.current
     val snackbarRequest =
-        MelonSnackbarRequest(
+        MelonSnackbarActionRequest(
             message = stringResource(snackbar_mixup_add_message),
             actionLabel = stringResource(snackbar_move_action_label),
             onClick = navigateToMixUp,

--- a/app/src/main/java/org/sopt/melon/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/org/sopt/melon/presentation/home/HomeScreen.kt
@@ -10,13 +10,27 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import org.sopt.melon.R.string.snackbar_mixup_add_message
+import org.sopt.melon.R.string.snackbar_move_action_label
+import org.sopt.melon.core.common.util.noRippleClickable
+import org.sopt.melon.core.designsystem.component.snackbar.LocalMelonSnackbarTrigger
+import org.sopt.melon.core.designsystem.component.snackbar.MelonSnackbarRequest
 
 @Composable
 fun HomeRoute(
     innerPadding: PaddingValues,
     navigateToMixUp: () -> Unit,
 ) {
+    val snackbarTrigger = LocalMelonSnackbarTrigger.current
+    val snackbarRequest = MelonSnackbarRequest(
+        message = stringResource(snackbar_mixup_add_message),
+        actionLabel = stringResource(snackbar_move_action_label),
+        onClick = navigateToMixUp,
+    )
+
     HomeScreen(
+        onMixUpClick = { snackbarTrigger(snackbarRequest) },
         modifier =
             Modifier
                 .padding(innerPadding),
@@ -25,6 +39,7 @@ fun HomeRoute(
 
 @Composable
 private fun HomeScreen(
+    onMixUpClick: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -34,6 +49,13 @@ private fun HomeScreen(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text("HOME", color = Color.White)
+        Text(
+            "HOME",
+            color = Color.White,
+            modifier = Modifier
+                .noRippleClickable(
+                    onClick = onMixUpClick,
+                ),
+        )
     }
 }

--- a/app/src/main/java/org/sopt/melon/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/org/sopt/melon/presentation/home/HomeScreen.kt
@@ -40,7 +40,7 @@ fun HomeRoute(
 
 @Composable
 private fun HomeScreen(
-    onMixUpClick: () -> Unit = {},
+    onMixUpClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(

--- a/app/src/main/java/org/sopt/melon/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/org/sopt/melon/presentation/home/HomeScreen.kt
@@ -23,11 +23,12 @@ fun HomeRoute(
     navigateToMixUp: () -> Unit,
 ) {
     val snackbarTrigger = LocalMelonSnackbarTrigger.current
-    val snackbarRequest = MelonSnackbarRequest(
-        message = stringResource(snackbar_mixup_add_message),
-        actionLabel = stringResource(snackbar_move_action_label),
-        onClick = navigateToMixUp,
-    )
+    val snackbarRequest =
+        MelonSnackbarRequest(
+            message = stringResource(snackbar_mixup_add_message),
+            actionLabel = stringResource(snackbar_move_action_label),
+            onClick = navigateToMixUp,
+        )
 
     HomeScreen(
         onMixUpClick = { snackbarTrigger(snackbarRequest) },
@@ -52,10 +53,11 @@ private fun HomeScreen(
         Text(
             "HOME",
             color = Color.White,
-            modifier = Modifier
-                .noRippleClickable(
-                    onClick = onMixUpClick,
-                ),
+            modifier =
+                Modifier
+                    .noRippleClickable(
+                        onClick = onMixUpClick,
+                    ),
         )
     }
 }

--- a/app/src/main/java/org/sopt/melon/presentation/main/MainScreen.kt
+++ b/app/src/main/java/org/sopt/melon/presentation/main/MainScreen.kt
@@ -52,7 +52,7 @@ fun MainScreen(
                 val request = snackbarController.currentRequest ?: return@SnackbarHost
 
                 MelonActionSnackbar(
-                    message = data.visuals.message,
+                    message = request.message,
                     actionLabel = request.actionLabel,
                     action = snackbarController::performAction,
                     modifier =

--- a/app/src/main/java/org/sopt/melon/presentation/main/MainScreen.kt
+++ b/app/src/main/java/org/sopt/melon/presentation/main/MainScreen.kt
@@ -39,9 +39,10 @@ fun MainScreen(
     navigator: MainNavigator = rememberMainNavigator(),
 ) {
     val snackbarController = rememberMelonSnackbarController()
-    val snackbarTrigger: (MelonSnackbarRequest) -> Unit = remember {
-        { request -> snackbarController.show(request) }
-    }
+    val snackbarTrigger: (MelonSnackbarRequest) -> Unit =
+        remember {
+            { request -> snackbarController.show(request) }
+        }
 
     Scaffold(
         snackbarHost = {

--- a/app/src/main/java/org/sopt/melon/presentation/main/MainScreen.kt
+++ b/app/src/main/java/org/sopt/melon/presentation/main/MainScreen.kt
@@ -9,12 +9,21 @@ import androidx.compose.animation.slideIn
 import androidx.compose.animation.slideOut
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
 import kotlinx.collections.immutable.toImmutableList
+import org.sopt.melon.core.designsystem.component.snackbar.LocalMelonSnackbarTrigger
+import org.sopt.melon.core.designsystem.component.snackbar.MelonActionSnackbar
+import org.sopt.melon.core.designsystem.component.snackbar.MelonSnackbarRequest
+import org.sopt.melon.core.designsystem.component.snackbar.rememberMelonSnackbarController
 import org.sopt.melon.core.designsystem.theme.MELONTheme
 import org.sopt.melon.presentation.drawer.drawerGraph
 import org.sopt.melon.presentation.foryou.navigation.forYouGraph
@@ -29,7 +38,32 @@ import org.sopt.melon.presentation.shortcut.shortCutGraph
 fun MainScreen(
     navigator: MainNavigator = rememberMainNavigator(),
 ) {
+    val snackbarController = rememberMelonSnackbarController()
+    val snackbarTrigger: (MelonSnackbarRequest) -> Unit = remember {
+        { request -> snackbarController.show(request) }
+    }
+
     Scaffold(
+        snackbarHost = {
+            SnackbarHost(
+                hostState = snackbarController.snackbarHostState,
+            ) { data ->
+                val request = snackbarController.currentRequest ?: return@SnackbarHost
+
+                MelonActionSnackbar(
+                    message = data.visuals.message,
+                    actionLabel = request.actionLabel,
+                    action = snackbarController::performAction,
+                    modifier =
+                        Modifier
+                            .padding(
+                                start = 16.dp,
+                                end = 16.dp,
+                                bottom = 16.dp,
+                            ),
+                )
+            }
+        },
         bottomBar = {
             AnimatedVisibility(
                 visible = navigator.showBottomBar(),
@@ -48,10 +82,14 @@ fun MainScreen(
         },
         containerColor = MELONTheme.colors.background,
     ) { innerPadding ->
-        MainNavHost(
-            navigator = navigator,
-            innerPadding = innerPadding,
-        )
+        CompositionLocalProvider(
+            LocalMelonSnackbarTrigger provides snackbarTrigger,
+        ) {
+            MainNavHost(
+                navigator = navigator,
+                innerPadding = innerPadding,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/org/sopt/melon/presentation/main/MainScreen.kt
+++ b/app/src/main/java/org/sopt/melon/presentation/main/MainScreen.kt
@@ -22,7 +22,7 @@ import androidx.navigation.compose.NavHost
 import kotlinx.collections.immutable.toImmutableList
 import org.sopt.melon.core.designsystem.component.snackbar.LocalMelonSnackbarTrigger
 import org.sopt.melon.core.designsystem.component.snackbar.MelonActionSnackbar
-import org.sopt.melon.core.designsystem.component.snackbar.MelonSnackbarRequest
+import org.sopt.melon.core.designsystem.component.snackbar.MelonSnackbarActionRequest
 import org.sopt.melon.core.designsystem.component.snackbar.rememberMelonSnackbarController
 import org.sopt.melon.core.designsystem.theme.MELONTheme
 import org.sopt.melon.presentation.drawer.drawerGraph
@@ -39,7 +39,7 @@ fun MainScreen(
     navigator: MainNavigator = rememberMainNavigator(),
 ) {
     val snackbarController = rememberMelonSnackbarController()
-    val snackbarTrigger: (MelonSnackbarRequest) -> Unit =
+    val snackbarTrigger: (MelonSnackbarActionRequest) -> Unit =
         remember {
             { request -> snackbarController.show(request) }
         }


### PR DESCRIPTION
## Related issue 🛠
- closed #14

## Work Description ✏️
- Snackbar 로직 구현

## Screenshot 📸
https://github.com/user-attachments/assets/7fb4a5af-c610-470e-abc6-357e58213965


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
스낵바 전역적으로 사용 할 수 있도록 composition local 을 적용해 보았습니다. home 화면에 텍스트 버튼 클릭시 호출되도록 구현해 놓았으니 참고해서 사용하시면 될것 같습니다 ~